### PR TITLE
Add make to list of packages to install

### DIFF
--- a/F32/Dockerfile
+++ b/F32/Dockerfile
@@ -16,7 +16,7 @@ RUN dnf -y install less htop net-tools which sudo keychain man wget vim || echo 
 ADD resources/bashrc /root/.bashrc
 
 # Fedora/CentOS/RedHat packaging
-RUN dnf -y install fedora-packager keyutils rpmconf dnf-utils git-all bash-completion Lmod || echo "Issue with installing fedora-packager. That's fine"
+RUN dnf -y install fedora-packager keyutils rpmconf dnf-utils git-all bash-completion Lmod make || echo "Issue with installing fedora-packager. That's fine"
 
 # Specific to C++-based packages (with Python bindings)
 RUN dnf -y install gcc-c++ boost-devel cmake python-devel python3-devel bzip2-devel m4 python2-numpy python3-numpy mpich-devel openmpi-devel || echo "Issue with installing boost-devel. That's fine"


### PR DESCRIPTION
To enable workflows where make drives a Makefile to build packages
where the specfile might need to be generated, as just one example.

If this is acceptable, I will push commits to update the other Dockerfiles.
Just didn't want to go to the effort before knowing if it would be acceptable
or not.